### PR TITLE
fix makeStreams2 missed rename

### DIFF
--- a/lib/combined-stream2.coffee
+++ b/lib/combined-stream2.coffee
@@ -28,7 +28,7 @@ makeStreams2 = (sourceStream) ->
 		return sourceStream.pipe(new stream.PassThrough())
 
 	debug "wrapping stream..."
-	wrapper = new stream.Readable().wrap(stream)
+	wrapper = new stream.Readable().wrap(sourceStream)
 
 	if sourceStream.destroy?
 		wrapper.destroy = sourceStream.destroy.bind(sourceStream)

--- a/lib/combined-stream2.js
+++ b/lib/combined-stream2.js
@@ -36,7 +36,7 @@ makeStreams2 = function(sourceStream) {
     return sourceStream.pipe(new stream.PassThrough());
   }
   debug("wrapping stream...");
-  wrapper = new stream.Readable().wrap(stream);
+  wrapper = new stream.Readable().wrap(sourceStream);
   if (sourceStream.destroy != null) {
     wrapper.destroy = sourceStream.destroy.bind(sourceStream);
   }


### PR DESCRIPTION
makeStreams2 uses Readable.wrap method, but passes stream module as
parameter instead of the intended sourceStream variable.
